### PR TITLE
added the native height and width to the html img tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         <div class="grid">
             <div class="card">
                 <div class="img">
-                    <img src="./images/chest_day.jpg" alt="">
+                    <img width="1188" height="1028" src="./images/chest_day.jpg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Chest Workout</h2>
@@ -69,7 +69,7 @@
             </div>
             <div class="card">
                 <div class="img">
-                    <img src="./images/back_day.jpg" alt="">
+                    <img width="800" height="450" src="./images/back_day.jpg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Back Workout</h2>
@@ -77,7 +77,7 @@
             </div>
             <div class="card">
                 <div class="img">
-                    <img src="./images/leg_day.jpeg" alt="">
+                    <img width="3032" height="2021" src="./images/leg_day.jpeg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Leg Workout</h2>
@@ -85,7 +85,7 @@
             </div>
             <div class="card">
                 <div class="img">
-                    <img src="./images/arm_day.jpg" alt="">
+                    <img width="480" height="323" src="./images/arm_day.jpg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Arm Workout</h2>
@@ -105,7 +105,7 @@
         <div class="grid">
             <div class="card">
                 <div class="img">
-                    <img src="./images/leg_day.jpeg" alt="" srcset="">
+                    <img width="3032" height="2021" src="./images/leg_day.jpeg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Leg Workout</h2>
@@ -117,7 +117,7 @@
 
             <div class="card">
                 <div class="img">
-                    <img src="./images/arm_day.jpg" alt="">
+                    <img width="480" height="323" src="./images/arm_day.jpg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Arm Workout</h2>
@@ -129,7 +129,7 @@
 
             <div class="card">
                 <div class="img">
-                    <img src="./images/chest_day.jpg" alt="" srcset="">
+                    <img width="1188" height="1028" src="./images/chest_day.jpg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Chest Day</h2>
@@ -142,7 +142,7 @@
 
             <div class="card">
                 <div class="img">
-                    <img src="./images/back_day.jpg" alt="">
+                    <img width="800" height="450" src="./images/back_day.jpg" alt="">
                 </div>
                 <div class="content">
                     <h2 class="title">Back Workout</h2>


### PR DESCRIPTION
I read a guide and it said to add the native height and width of the images in the <img tag> so I did so. I am aware of the aspect ratio 16:9 but I did not exactly understand whether I should add the native dimensions or I should calculate the perfect dimensions. As the guide also said that we need to used the dimensions that are as close as the original dimensions. 